### PR TITLE
Refactor handling of attachedCard and PoPP token

### DIFF
--- a/client/vsdm-client-simservice-java/src/main/java/de/gematik/ti20/simsvc/client/service/VsdmClientService.java
+++ b/client/vsdm-client-simservice-java/src/main/java/de/gematik/ti20/simsvc/client/service/VsdmClientService.java
@@ -125,7 +125,17 @@ public class VsdmClientService implements PoppTokenSessionEventHandler {
         smcbSlotId,
         ifNoneMatch,
         poppTokenInjected != null);
-    final AttachedCard attachedCard = getAttachedCard(terminalId, egkSlotId);
+
+    final AttachedCard attachedCard;
+
+    if (poppTokenInjected != null && !poppTokenInjected.isEmpty()) {
+      log.debug("Using provided PoPP token, skipping Popp-Service call");
+      attachedCard = null;
+      // poppToken = poppTokenInjected;
+    } else {
+      attachedCard = getAttachedCard(terminalId, egkSlotId);
+      // poppToken = requestPoppToken(terminalId, egkSlotId, smcbSlotId, attachedCard);
+    }
 
     final String poppToken =
         Optional.ofNullable(poppTokenInjected)
@@ -214,14 +224,17 @@ public class VsdmClientService implements PoppTokenSessionEventHandler {
       final String ifNoneMatch,
       final boolean isFhirXml) {
 
-    final VsdmCachedValue vsdmCachedValue =
-        vsdmDataRepository.get(terminal, egkSlotId, attachedCard.getId());
+    // Skip cache if attachedCard is null (when poppToken is provided externally)
+    if (attachedCard != null) {
+      final VsdmCachedValue vsdmCachedValue =
+          vsdmDataRepository.get(terminal, egkSlotId, attachedCard.getId());
 
-    if (vsdmCachedValue != null) {
-      return ResponseEntity.status(HttpStatus.OK)
-          .header(HEADER_VSDM_PZ, vsdmCachedValue.pruefziffer())
-          .header(HEADER_ETAG, vsdmCachedValue.etag())
-          .body(vsdmCachedValue.vsdmData());
+      if (vsdmCachedValue != null) {
+        return ResponseEntity.status(HttpStatus.OK)
+            .header(HEADER_VSDM_PZ, vsdmCachedValue.pruefziffer())
+            .header(HEADER_ETAG, vsdmCachedValue.etag())
+            .body(vsdmCachedValue.vsdmData());
+      }
     }
 
     try {
@@ -252,14 +265,17 @@ public class VsdmClientService implements PoppTokenSessionEventHandler {
       }
       responseHeaders.put("Content-Type", List.of(MediaType.FHIR_JSON.asString()));
 
-      vsdmDataRepository.put(
-          terminal,
-          egkSlotId,
-          attachedCard.getId(),
-          new VsdmCachedValue(
-              responseHeaders.getETag(),
-              responseHeaders.getFirst(HEADER_VSDM_PZ),
-              responseToCaller));
+      // Only cache if attachedCard is available
+      if (attachedCard != null) {
+        vsdmDataRepository.put(
+            terminal,
+            egkSlotId,
+            attachedCard.getId(),
+            new VsdmCachedValue(
+                responseHeaders.getETag(),
+                responseHeaders.getFirst(HEADER_VSDM_PZ),
+                responseToCaller));
+      }
 
       return ResponseEntity.status(HttpStatus.OK).headers(responseHeaders).body(responseToCaller);
 
@@ -269,14 +285,22 @@ public class VsdmClientService implements PoppTokenSessionEventHandler {
     } catch (final ServerResponseException e) {
       log.error("Error while connecting to VSDM server: {}", e.getMessage(), e);
 
-      try {
-        final String responseToCaller = loadTruncatedDataFromCard(attachedCard);
-        if (responseToCaller == null) {
-          return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+      // Fallback to card data only if attachedCard is available
+      if (attachedCard != null) {
+        try {
+          final String responseToCaller = loadTruncatedDataFromCard(attachedCard);
+          if (responseToCaller == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+          }
+          return ResponseEntity.status(HttpStatus.OK).body(responseToCaller);
+        } catch (final CardTerminalException cardEx) {
+          log.error(
+              "Error while loading truncated data from card: {}", cardEx.getMessage(), cardEx);
+          throw new ResponseStatusException(
+              HttpURLConnection.HTTP_INTERNAL_ERROR, e.getMessage(), e);
         }
-        return ResponseEntity.status(HttpStatus.OK).body(responseToCaller);
-      } catch (final CardTerminalException cardEx) {
-        log.error("Error while loading truncated data from card: {}", cardEx.getMessage(), cardEx);
+      } else {
+        // No fallback available when using provided token
         throw new ResponseStatusException(HttpURLConnection.HTTP_INTERNAL_ERROR, e.getMessage(), e);
       }
     } catch (InterruptedException e) {
@@ -308,15 +332,18 @@ public class VsdmClientService implements PoppTokenSessionEventHandler {
         checkDigitHeader,
         "'%s' header must be set by VSDM backend on 304".formatted(HEADER_VSDM_PZ));
 
-    final VsdmCachedValue cachedValue =
-        vsdmDataRepository.get(terminal, egkSlotId, attachedCard.getId());
-    final VsdmCachedValue updatedCacheValue;
-    if (cachedValue == null) {
-      updatedCacheValue = new VsdmCachedValue(etagHeader, checkDigitHeader, "");
-    } else {
-      updatedCacheValue = cachedValue.copyWith(etagHeader, checkDigitHeader);
+    // Only update cache if attachedCard is available
+    if (attachedCard != null) {
+      final VsdmCachedValue cachedValue =
+          vsdmDataRepository.get(terminal, egkSlotId, attachedCard.getId());
+      final VsdmCachedValue updatedCacheValue;
+      if (cachedValue == null) {
+        updatedCacheValue = new VsdmCachedValue(etagHeader, checkDigitHeader, "");
+      } else {
+        updatedCacheValue = cachedValue.copyWith(etagHeader, checkDigitHeader);
+      }
+      vsdmDataRepository.put(terminal, egkSlotId, attachedCard.getId(), updatedCacheValue);
     }
-    vsdmDataRepository.put(terminal, egkSlotId, attachedCard.getId(), updatedCacheValue);
     return ResponseEntity.status(HttpStatus.NOT_MODIFIED).headers(responseHeaders).build();
   }
 


### PR DESCRIPTION
This pull request updates the `VsdmClientService` to improve how external PoPP tokens are handled, ensuring that card-related operations and caching are only performed when an attached card is present. This prevents unnecessary or invalid cache operations and fallback logic when a PoPP token is injected externally, making the service more robust and predictable.

**Handling of externally provided PoPP tokens and attached card logic:**

* Skips the `getAttachedCard` call and sets `attachedCard` to `null` when a PoPP token is provided externally, avoiding unnecessary card operations.
* Updates cache operations in `requestVsd` to only read from or write to the cache if `attachedCard` is present, preventing cache pollution when using external tokens. [[1]](diffhunk://#diff-8ea0a26352798215a881d08d02f0082af5d393fbae3ef39ef82ac7f85523f9d2R227-R228) [[2]](diffhunk://#diff-8ea0a26352798215a881d08d02f0082af5d393fbae3ef39ef82ac7f85523f9d2R238) [[3]](diffhunk://#diff-8ea0a26352798215a881d08d02f0082af5d393fbae3ef39ef82ac7f85523f9d2R268-R269) [[4]](diffhunk://#diff-8ea0a26352798215a881d08d02f0082af5d393fbae3ef39ef82ac7f85523f9d2R278) [[5]](diffhunk://#diff-8ea0a26352798215a881d08d02f0082af5d393fbae3ef39ef82ac7f85523f9d2R335-R336) [[6]](diffhunk://#diff-8ea0a26352798215a881d08d02f0082af5d393fbae3ef39ef82ac7f85523f9d2R346)

**Fallback and error handling improvements:**

* Ensures that fallback to card data on server errors only occurs if `attachedCard` is available; otherwise, a proper error response is returned when using an external PoPP token.